### PR TITLE
Turn off VAD auto responses to wait for intent detection completion

### DIFF
--- a/voice_agent/app/backend/rtmt.py
+++ b/voice_agent/app/backend/rtmt.py
@@ -71,6 +71,7 @@ class RTMiddleTier:
     _token_provider = None
     transfer_conversation = False
     target_agent_name = None
+    intent_detection_complete = False
     history = []
     init_user_question = None
     session_state = SessionState() #to backup the state of the conversation
@@ -148,6 +149,7 @@ class RTMiddleTier:
             self.target_agent_name = intent
             logger.info("Switching to new agent: %s", self.target_agent_name)  
             self.transfer_conversation = True  
+        self.intent_detection_complete = True
 
             
 
@@ -159,7 +161,8 @@ class RTMiddleTier:
                     "type": "server_vad",
                             "threshold": 0.5,
                             "prefix_padding_ms": 300,
-                            "silence_duration_ms": 200
+                            "silence_duration_ms": 200,
+                            "create_response": False
 
                 },
                 "input_audio_transcription": {
@@ -303,7 +306,7 @@ class RTMiddleTier:
                         # todo: extend the conversation history when transfer conversation so that next agent has more context. Last request might not be sufficient
                         # Trigger intent detection
                         if self.use_classification_model:   
-                            asyncio.create_task(self._detect_intent_change())  
+                            await self._detect_intent_change()                            
 
                     # Retain only the last n turnss  
                     if len(self.history) > self.max_history_length:  
@@ -358,8 +361,8 @@ class RTMiddleTier:
 
         return updated_message
     async def _reinitialize_state(self, target_ws: web.WebSocketResponse):
-        logger.info("cancelling current response")
-        await target_ws.send_json({"type": "response.cancel"})
+        #logger.info("cancelling current response")
+        #await target_ws.send_json({"type": "response.cancel"})
         logger.info("Reinitializing session state")  
         server_msg = {"type":"input_audio_buffer.clear"}
         logger.info("Cleared audio buffer")  
@@ -395,19 +398,23 @@ class RTMiddleTier:
                         if msg.type == aiohttp.WSMsgType.TEXT:
                             new_msg = await self._process_message_to_client(msg, ws, target_ws)
                             
-                            if new_msg is not None and self.target_agent_name is None:
-
+                            if self.target_agent_name is not None:
+                                self.current_agent = next((agent for agent in self.agents if agent.get('name') == self.target_agent_name), None)
+                                self.set_current_agent_tools()
+                                self.transfer_conversation = False
+                                self.target_agent_name = None
+                                await self._reinitialize_state(target_ws)
+                                print("Firing response.create to respond after reinitialized state.")
+                                await target_ws.send_json({'type': 'response.create'})
+                            
+                            elif self.intent_detection_complete:
+                                self.intent_detection_complete = False
+                                print("Firing response.create to respond after intent detection.")
+                                await target_ws.send_json({'type': 'response.create'})
+                            
+                            elif new_msg is not None:
+                                #logger.info("Sending message to client: %s", new_msg)
                                 await ws.send_str(new_msg)
-                            else:
-                                if self.target_agent_name is not None:
-
-                                    self.current_agent = next((agent for agent in self.agents if agent.get('name') == self.target_agent_name), None)
-                                    self.set_current_agent_tools()
-                                    self.transfer_conversation = False
-                                    self.target_agent_name = None
-                                    await self._reinitialize_state(target_ws)
-
-                                    await target_ws.send_json({'type': 'response.create'})
 
 
                         else:

--- a/voice_agent/app/backend/rtmt.py
+++ b/voice_agent/app/backend/rtmt.py
@@ -309,7 +309,6 @@ class RTMiddleTier:
                                 self.target_agent_name = None
                                 await self._reinitialize_state(server_ws)
                             
-                            print("Firing response.create to respond after intent detection.")
                             await server_ws.send_json({'type': 'response.create'})                        
 
                     # Retain only the last n turnss  
@@ -365,8 +364,6 @@ class RTMiddleTier:
 
         return updated_message
     async def _reinitialize_state(self, target_ws: web.WebSocketResponse):
-        #logger.info("cancelling current response")
-        #await target_ws.send_json({"type": "response.cancel"})
         logger.info("Reinitializing session state")  
         server_msg = {"type":"input_audio_buffer.clear"}
         logger.info("Cleared audio buffer")  
@@ -400,13 +397,9 @@ class RTMiddleTier:
                 async def from_server_to_client():
                     async for msg in target_ws:
                         if msg.type == aiohttp.WSMsgType.TEXT:
-                            new_msg = await self._process_message_to_client(msg, ws, target_ws)
-                                                        
+                            new_msg = await self._process_message_to_client(msg, ws, target_ws)                  
                             if new_msg is not None:
-                                #logger.info("Sending message to client: %s", new_msg)
                                 await ws.send_str(new_msg)
-
-
                         else:
                             logger.error("Unexpected message type from server: %s", msg.type)  
 


### PR DESCRIPTION
This update ensures agent responses will be held until the intent detection and agent reassignment (if necessary) processes are completed. It makes use of the [Keep VAD, but disable automatic responses](https://platform.openai.com/docs/guides/realtime-model-capabilities#keep-vad-but-disable-automatic-responses) feature, released in the 12/17 version of the realtime API.

The intent detection and agent reassignment processes are await(ed) to ensure responses aren't created until they're completed.