### PR TITLE
Fix response.create logic and max output limit

### DIFF
--- a/voice_agent/app/backend/semantic_kernel/connectors/ai/open_ai/services/azure_realtime.py
+++ b/voice_agent/app/backend/semantic_kernel/connectors/ai/open_ai/services/azure_realtime.py
@@ -95,7 +95,6 @@ class AzureRealtimeWebsocket(OpenAIRealtimeWebsocketBase, AzureOpenAIConfigBase)
             raise ServiceInitializationError("Failed to create OpenAI settings.", ex) from ex
         if not azure_openai_settings.realtime_deployment_name:
             raise ServiceInitializationError("The OpenAI realtime model ID is required.")
-        print("api key inside realtime ", azure_openai_settings.api_key)
         super().__init__(
             audio_output_callback=audio_output_callback,
             deployment_name=azure_openai_settings.realtime_deployment_name,


### PR DESCRIPTION
Fixes two intermittent issues with the app

1. Added logic to avoid sending `response.create` events if there was already an active response, which was the cause behind the error: "Conversation already has an active response"
2. Upped the max output token limit which was frequently causing the response audio to get cut off before finishing