### PR TITLE
feat: add aspire dashboard in custom vnet

### DIFF
--- a/voice_agent/app/infra/core/host/container-app-upsert.bicep
+++ b/voice_agent/app/infra/core/host/container-app-upsert.bicep
@@ -71,6 +71,9 @@ param serviceBinds array = []
 @description('The target port for the container')
 param targetPort int = 80
 
+@description('Additional ports to expose (optional)')
+param additionalPorts array = []
+
 resource existingApp 'Microsoft.App/containerApps@2023-05-02-preview' existing = if (exists) {
   name: name
 }
@@ -101,6 +104,7 @@ module app 'container-app.bicep' = {
     imageName: !empty(imageName) ? imageName : exists ? existingApp.properties.template.containers[0].image : ''
     targetPort: targetPort
     serviceBinds: serviceBinds
+    additionalPorts: additionalPorts
   }
 }
 

--- a/voice_agent/app/infra/core/host/container-app.bicep
+++ b/voice_agent/app/infra/core/host/container-app.bicep
@@ -75,6 +75,9 @@ param serviceType string = ''
 @description('The target port for the container')
 param targetPort int = 80
 
+@description('Additional ports to expose (optional)')
+param additionalPorts array = []
+
 resource userIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if (!empty(identityName)) {
   name: identityName
 }
@@ -117,6 +120,8 @@ resource app 'Microsoft.App/containerApps@2023-05-02-preview' = {
         corsPolicy: {
           allowedOrigins: union([ 'https://portal.azure.com', 'https://ms.portal.azure.com' ], allowedOrigins)
         }
+        // Add additional exposed ports if specified
+        additionalPortMappings: !empty(additionalPorts) ? additionalPorts : null
       } : null
       dapr: daprEnabled ? {
         enabled: true

--- a/voice_agent/app/infra/core/host/container-apps-environment.bicep
+++ b/voice_agent/app/infra/core/host/container-apps-environment.bicep
@@ -12,6 +12,9 @@ param daprEnabled bool = false
 @description('Name of the Log Analytics workspace')
 param logAnalyticsWorkspaceName string
 
+@description('infrastructure subnet id')
+param infrastructureSubnetId string
+
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
   name: name
   location: location
@@ -25,7 +28,12 @@ resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01'
       }
     }
     daprAIInstrumentationKey: daprEnabled && !empty(applicationInsightsName) ? applicationInsights.properties.InstrumentationKey : ''
+    vnetConfiguration: !empty(infrastructureSubnetId) ? {
+      infrastructureSubnetId: infrastructureSubnetId
+      internal: false
+    } : null
   }
+  
 }
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {

--- a/voice_agent/app/infra/core/host/container-apps.bicep
+++ b/voice_agent/app/infra/core/host/container-apps.bicep
@@ -10,6 +10,7 @@ param containerRegistryAdminUserEnabled bool = false
 param logAnalyticsWorkspaceName string = ''
 param applicationInsightsName string = ''
 param daprEnabled bool = false
+param infrastructureSubnetId string = ''
 
 module containerAppsEnvironment 'container-apps-environment.bicep' = {
   name: '${name}-container-apps-environment'
@@ -20,6 +21,7 @@ module containerAppsEnvironment 'container-apps-environment.bicep' = {
     logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
     applicationInsightsName: applicationInsightsName
     daprEnabled: daprEnabled
+    infrastructureSubnetId: infrastructureSubnetId
   }
 }
 

--- a/voice_agent/app/infra/core/host/networking.bicep
+++ b/voice_agent/app/infra/core/host/networking.bicep
@@ -1,0 +1,69 @@
+@description('The Azure region for the resources.')
+param location string
+
+@description('Tags to apply to the resources.')
+param tags object = {}
+
+@description('Name for the virtual network.')
+param vnetName string
+
+@description('Address prefix for the virtual network.')
+param vnetAddressPrefix string
+
+@description('Name for the infrastructure subnet.')
+param infrastructureSubnetName string = 'infrastructure-subnet'
+
+@description('Address prefix for the infrastructure subnet.')
+param infrastructureSubnetPrefix string
+
+@description('Name for the Container Apps subnet.')
+param containerAppsSubnetName string = 'containerapps-subnet'
+
+@description('Address prefix for the Container Apps subnet.')
+param containerAppsSubnetPrefix string
+
+// Create the virtual network
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+  name: vnetName
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: infrastructureSubnetName
+        properties: {
+          addressPrefix: infrastructureSubnetPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: containerAppsSubnetName
+        properties: {
+          addressPrefix: containerAppsSubnetPrefix
+          delegations: [
+            {
+              name: 'Microsoft.App.environments'
+              properties: {
+                serviceName: 'Microsoft.App/environments'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// Output the subnet details
+output vnetId string = virtualNetwork.id
+output vnetName string = virtualNetwork.name
+output infrastructureSubnetId string = virtualNetwork.properties.subnets[0].id
+output containerAppsSubnetId string = virtualNetwork.properties.subnets[1].id
+output infrastructureSubnetName string = infrastructureSubnetName
+output containerAppsSubnetName string = containerAppsSubnetName

--- a/voice_agent/app/infra/main.bicep
+++ b/voice_agent/app/infra/main.bicep
@@ -18,6 +18,27 @@ param applicationInsightsDashboardName string = ''
 @description('Name of the Azure Application Insights resource')
 param applicationInsightsName string = ''
 
+@description('Name of the aspire dashboard container app')
+param aspireDashboardName string = 'aspire-dashboard'
+
+@description('Target port for the Aspire dashboard')
+param aspireDashboardTargetPort int = 18888
+
+@description('Image name for the Aspire dashboard')
+param aspireDashboardImageName string = 'mcr.microsoft.com/dotnet/aspire-dashboard:9.0'
+
+@description('Exposed port for Aspire dashboard additional endpoint for gRPC')
+param aspireDashboardAdditionalGrpcExposedPort int = 18889
+
+@description('Target port for Aspire dashboard additional endpoint for gRPC')
+param aspireDashboardAdditionalGrpcTargetPort int = 4317
+
+@description('Exposed port for Aspire dashboard additional endpoint for HTTP')
+param aspireDashboardAdditionalHttpExposedPort int = 18890
+
+@description('Target port for Aspire dashboard additional endpoint for HTTP')
+param aspireDashboardAdditionalHttpTargetPort int = 18890
+
 @description('Name of the Azure Log Analytics workspace')
 param logAnalyticsName string = ''
 
@@ -78,6 +99,24 @@ param principalType string = 'User'
 @description('Name of the resource group for the OpenAI resources')
 param openAiResourceGroupName string = ''
 
+// Add virtual network parameters
+@description('Name of the virtual network')
+param vnetName string = ''
+
+@description('Address prefix for the virtual network')
+param vnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Name for the infrastructure subnet')
+param infrastructureSubnetName string = 'infrastructure-subnet'
+
+@description('Address prefix for the infrastructure subnet')
+param infrastructureSubnetPrefix string = '10.0.0.0/23'
+
+@description('Name for the Container Apps subnet')
+param containerAppsSubnetName string = 'containerapps-subnet'
+
+@description('Address prefix for the Container Apps subnet')
+param containerAppsSubnetPrefix string = '10.0.2.0/23'
 
 // Organize resources in a resource group
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
@@ -94,6 +133,21 @@ resource azureOpenAiResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01
   name: !empty(openAiResourceGroupName) ? openAiResourceGroupName : resourceGroup.name
 }
 
+// Create networking resources
+module networking './core/host/networking.bicep' = {
+  name: 'networking'
+  scope: resourceGroup
+  params: {
+    location: location
+    tags: tags
+    vnetName: !empty(vnetName) ? vnetName : '${abbrs.networkVirtualNetworks}${resourceToken}'
+    vnetAddressPrefix: vnetAddressPrefix
+    infrastructureSubnetName: infrastructureSubnetName
+    infrastructureSubnetPrefix: infrastructureSubnetPrefix
+    containerAppsSubnetName: containerAppsSubnetName
+    containerAppsSubnetPrefix: containerAppsSubnetPrefix
+  }
+}
 
 // Create a user assigned identity
 module identity './core/security/user-assigned-identity.bicep' = {
@@ -129,6 +183,8 @@ module containerApps 'core/host/container-apps.bicep' = {
     containerRegistryResourceGroupName: !empty(containerRegistryResourceGroupName) ? containerRegistryResourceGroupName : resourceGroup.name
     location: location
     logAnalyticsWorkspaceName: monitoring.outputs.logAnalyticsWorkspaceName
+    // Pass the subnet ID to the container apps module
+    infrastructureSubnetId: networking.outputs.infrastructureSubnetId
   }
 }
 
@@ -152,7 +208,6 @@ module aiServices './core/ai/ai-services.bicep' = {
     abbrs: abbrs
   }
 }
-
 
 // Deploy individual container apps
 module backendApp './app/backend.bicep' = {
@@ -199,6 +254,46 @@ module frontendApp './app/frontend.bicep' = {
     viteBackendWsUrl: backendApp.outputs.SERVICE_BACKEND_URI
   }
 }
+
+// Deploy Aspire Dashboard
+module aspireDashboard 'core/host/container-app-upsert.bicep' = {
+  name: '${deployment().name}-dash'
+  scope: resourceGroup
+  params: {
+    name: aspireDashboardName
+    location: location
+    tags: tags
+    containerAppsEnvironmentName: containerApps.outputs.environmentName
+    containerName: 'aspire-dashboard'
+    imageName: aspireDashboardImageName
+    ingressEnabled: true
+    external: true
+    targetPort: aspireDashboardTargetPort
+    additionalPorts: [
+      {
+        exposedPort: aspireDashboardAdditionalGrpcExposedPort
+        targetPort: aspireDashboardAdditionalGrpcTargetPort
+      }
+      {
+        exposedPort: aspireDashboardAdditionalHttpExposedPort
+        targetPort: aspireDashboardAdditionalHttpTargetPort
+      }
+    ]
+    env: [
+      {
+        name: 'ASPNETCORE_ENVIRONMENT'
+        value: 'Production'
+      }
+      {
+        name: 'ASPNETCORE_URLS'
+        value: 'http://+:${aspireDashboardTargetPort}'
+      }
+    ]
+  }
+}
+
+// Add an output for the Aspire Dashboard URL
+output ASPIRE_DASHBOARD_URI string = aspireDashboard.outputs.uri
 
 module storage 'core/storage/storage-account.bicep' = {
   name: 'storage'
@@ -308,4 +403,4 @@ output SERVICE_FRONTEND_IDENTITY_NAME string = frontendApp.outputs.SERVICE_FRONT
 output SERVICE_FRONTEND_NAME string = frontendApp.outputs.SERVICE_FRONTEND_NAME
 output SERVICE_BACKEND_IDENTITY_NAME string = backendApp.outputs.SERVICE_BACKEND_IDENTITY_NAME
 output SERVICE_BACKEND_NAME string = backendApp.outputs.SERVICE_BACKEND_NAME
-
+output ASPIRE_DASHBOARD_FQDN string = aspireDashboard.outputs.defaultDomain


### PR DESCRIPTION
- Deploy ACA environment in a custom VNet because it's required for a container with multiple ports
- Add an ACA app with Aspire Dashboard, with the UI port (18888) and OTLP ports (18889 for gRPC and 18890 for HTTP) mapped. Confirmed it's started up and listening on those ports, UI is accessible from public ingress.
- Did not use the managed Aspire Dashboard in ACA because it's only for .NET applications, won't work for python.