### PR TITLE
Fix start.sh

### DIFF
--- a/voice_agent/app/start.sh
+++ b/voice_agent/app/start.sh
@@ -37,7 +37,7 @@ npm install || { echo "Frontend npm installation failed."; exit 1; }
 # • This file can contain environment variables such as BACKEND_WS_URL that Vite will load.  
 #  
 # Example .env file:  
-VITE_BACKEND_WS_URL="ws://localhost:8765"  
+export VITE_BACKEND_WS_URL="ws://localhost:8765"  
   
 echo ""  
 echo "Starting frontend dev server..."  


### PR DESCRIPTION
Fixes `start.sh` script by adding export for VITE_BACKEND_WS_URL