### PR TITLE
feat: improve local dashboard configuration by using docker compose

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,32 @@
+# Use the Python 3.12 base image
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# Install Azure CLI
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends ca-certificates curl apt-transport-https lsb-release gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg \
+    && echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update \
+    && apt-get -y install azure-cli \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm
+
+# Install Azure Developer CLI (azd)
+RUN curl -fsSL https://aka.ms/install-azd.sh | bash
+
+# Set environment variables
+ENV ASPIRE_DASHBOARD_ENDPOINT=http://aspire-dashboard:18889
+
+# Create the workspace folder
+RUN mkdir -p /workspaces/multi-modal-customer-service-agent
+
+WORKDIR /workspaces/multi-modal-customer-service-agent
+
+# Keep the container running
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,11 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-    "name": "multi-modal AI Agent",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
-    // Features to add to the dev container. More info: https://containers.dev/features.
-    "features": {
-        "ghcr.io/devcontainers/features/azure-cli:1": {},
-        "ghcr.io/azure/azure-dev/azd:latest": {},
-        "ghcr.io/devcontainers/features/node:1": {
-            "version": "20"
-        }
-    },
+    "name": "Multi-Modal Customer Service Agent",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "devcontainer",
+    "workspaceFolder": "/workspaces/multi-modal-customer-service-agent",
+    
     // Configure tool-specific properties.
     "customizations": {
         "vscode": {
@@ -21,7 +16,10 @@
                 "esbenp.prettier-vscode",
                 "bradlc.vscode-tailwindcss",
                 "GitHub.copilot-chat"
-            ]
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/local/bin/python"
+            }
         }
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  devcontainer:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/multi-modal-customer-service-agent:cached
+    command: sleep infinity
+    networks:
+      - dev-network
+    
+  aspire-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:9.0
+    restart: unless-stopped
+    ports:
+      - "18888:18888"
+      - "4317:18889"
+    environment:
+      - DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true
+    networks:
+      - dev-network
+
+networks:
+  dev-network:
+    driver: bridge

--- a/docs/03_observability/README.md
+++ b/docs/03_observability/README.md
@@ -32,19 +32,17 @@ The bicep infrastructure deploys an Application Insights resource where you can 
 
 ### Local Configuration
 
-You can see telemetry data if you are running the app locally, in a local dev container, or in Azure via `azd up`. It will not work if you're running in Github Codespaces. 
+You can see telemetry data if you are running the app locally, in a local dev container, or in Azure via `azd up`. If you are using Github Codespaces, there is no observability data. We recommend you run `azd up` and interact with the app in Azure environment to see observability data.
 
-If running locally or in a dev container, there are configuration steps to wire up the Aspire Dashboard:
+Configuration steps to wire up the Aspire Dashboard:
 1. Update the `.env` file with this value: `TELEMETRY_SCENARIO=console,aspire_dashboard`
-1. Run this command to host the Aspire Dashboard in a local container:
-
-   ```bash
-   docker run --rm -it -d -p 18888:18888 -p 4317:18889 -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:9.0
-   ```
-
-If running locally (not in a dev container), update the `.env` file with this value: `ASPIRE_DASHBOARD_ENDPOINT=http://localhost:4317`
-
-No additional steps are needed if you are running the app that was deployed by `azd up`.
+1. If running the app locally (no dev container), follow these steps:
+    1. ```bash
+        docker run --rm -it -d -p 18888:18888 -p 4317:18889 -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:9.0
+        ```
+    2. In `.env`, set `ASPIRE_DASHBOARD_ENDPOINT` to `http://localhost:4317`
+1. If running the app in a dev container, `docker-compose.yml` spins up the dashboard alongside your dev container. In `.env` set `ASPIRE_DASHBOARD_ENDPOINT` to `http://aspire-dashboard:18889` 
+1. In the Azure environment, no additional steps are needed to configure observability.
 
 ### Conduct a conversation with the customer service agents
 
@@ -56,9 +54,14 @@ Conduct a conversation with the customer service agents following this sequence:
 
 ### Observe application behavior in Aspire Dashboard
 
+Browse the Aspire Dashboard:
+1. If running locally or in a dev container, go to [http://localhost:18888](http://localhost:18888)
+1. If running in Azure:
 - Go to your resource group in Azure Portal
 - Click on the `aspire-dashboard` resource
 - Click on the `Application URL` in the top right corner to navigate to the dashboard
+
+See the observability data:
 ![Logs](../../media/aspire_dashboard_logs.png)
 - Observe the application log showing the conversation you conducted. Locate an entry: "Function hotel_tools-load_user_reservation_info invoking." and click on the Trace link. This navigates you to the Trace page for that function call.
 - Observe the details of the trace, such as the duration and other metadata.

--- a/docs/03_observability/README.md
+++ b/docs/03_observability/README.md
@@ -32,7 +32,7 @@ The bicep infrastructure deploys an Application Insights resource where you can 
 
 ### Local Configuration
 
-You can see telemetry data if you are running the app locally, in a local dev container, or in Azure via `azd up`. If you are using Github Codespaces, there is no observability data. We recommend you run `azd up` and interact with the app in Azure environment to see observability data.
+You can see telemetry data if you are running the app locally, in a local dev container, or in Azure via `azd up`. If you are using GitHub Codespaces, there is no observability data. We recommend you run `azd up` and interact with the app in Azure environment to see observability data.
 
 Configuration steps to wire up the Aspire Dashboard:
 1. Update the `.env` file with this value: `TELEMETRY_SCENARIO=console,aspire_dashboard`

--- a/voice_agent/app/backend/.env.sample
+++ b/voice_agent/app/backend/.env.sample
@@ -18,5 +18,6 @@ TURN_DETECTION_PREFIX_PADDING_MS=300
 TURN_DETECTION_SILENCE_DURATION_MS=200
 AZURE_REDIS_ENDPOINT=#optional, if you want to use redis for caching which support distributed caching for high
 AZURE_REDIS_KEY=#optional, if you want to use redis for caching which support distributed caching for high
-ASPIRE_DASHBOARD_ENDPOINT=http://host.docker.internal:4317
+#ASPIRE_DASHBOARD_ENDPOINT=http://aspire-dashboard:18889 # if running in a dev container
+#ASPIRE_DASHBOARD_ENDPOINT=http://localhost:4317 # if running locally (no dev container)
 TELEMETRY_SCENARIO=console


### PR DESCRIPTION
For users working in a dev container, use `docker-compose.yml` to spin up the Aspire Dashboard locally.
- Move dev container configuration to a new `Dockerfile`
- Add `docker-compose.yml` with two containers (dev and dashboard)
- Update instructions